### PR TITLE
fix: バージョン管理の仕組みを導入

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,19 @@
       "name": "apd",
       "source": "./",
       "description": "APD (Autopilot Development) Framework - 人間は意思決定だけ、AIが自律で完走する",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "author": {
         "name": "koyakimu"
       },
       "homepage": "https://github.com/koyakimu/autopilot-development-boilerplate",
       "license": "MIT",
-      "keywords": ["apd", "autonomous", "development", "framework", "ai-driven"]
+      "keywords": [
+        "apd",
+        "autonomous",
+        "development",
+        "framework",
+        "ai-driven"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apd",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "APD (Autopilot Development) Framework - AI自律開発フレームワーク。人間は意思決定だけ、AIが自律で完走する。",
   "author": {
     "name": "koyakimu",
@@ -8,5 +8,11 @@
   },
   "repository": "https://github.com/koyakimu/autopilot-development-boilerplate",
   "license": "MIT",
-  "keywords": ["apd", "autonomous", "development", "framework", "ai-driven"]
+  "keywords": [
+    "apd",
+    "autonomous",
+    "development",
+    "framework",
+    "ai-driven"
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# APD Framework - 開発ルール
+
+## バージョン管理
+
+- 機能追加・バグ修正をコミットする際は、必ずバージョンを更新する
+- バージョン更新は `./scripts/bump-version.sh <major|minor|patch>` を使用する（`plugin.json` と `marketplace.json` を一括更新）
+- semver に従う: breaking change → major、機能追加 → minor、バグ修正 → patch

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/bump-version.sh <major|minor|patch>
+# Updates version in plugin.json and marketplace.json
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_JSON="$ROOT_DIR/.claude-plugin/plugin.json"
+MARKETPLACE_JSON="$ROOT_DIR/.claude-plugin/marketplace.json"
+
+if [[ $# -ne 1 ]] || [[ ! "$1" =~ ^(major|minor|patch)$ ]]; then
+  echo "Usage: $0 <major|minor|patch>"
+  exit 1
+fi
+
+BUMP_TYPE="$1"
+
+# Get current version from plugin.json
+CURRENT_VERSION=$(python3 -c "import json; print(json.load(open('$PLUGIN_JSON'))['version'])")
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "$BUMP_TYPE" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+
+# Update plugin.json
+python3 -c "
+import json
+with open('$PLUGIN_JSON', 'r') as f:
+    data = json.load(f)
+data['version'] = '$NEW_VERSION'
+with open('$PLUGIN_JSON', 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+"
+
+# Update marketplace.json
+python3 -c "
+import json
+with open('$MARKETPLACE_JSON', 'r') as f:
+    data = json.load(f)
+for plugin in data.get('plugins', []):
+    if plugin.get('name') == 'apd':
+        plugin['version'] = '$NEW_VERSION'
+with open('$MARKETPLACE_JSON', 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+"
+
+echo "$CURRENT_VERSION -> $NEW_VERSION"


### PR DESCRIPTION
## Summary

- `scripts/bump-version.sh` を追加（`plugin.json` と `marketplace.json` のバージョンを一括更新）
- `CLAUDE.md` にバージョン管理ルールを追加（コミット時のバージョン更新を忘れない仕組み）
- 初期バージョンを `0.1.0` に設定

Closes #8

## Test plan

- [x] `./scripts/bump-version.sh patch` で `0.1.0 -> 0.1.1` に更新されることを確認済み
- [ ] `./scripts/bump-version.sh minor` で minor バージョンが上がることを確認
- [ ] `./scripts/bump-version.sh major` で major バージョンが上がることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)