### PR TITLE
fix: plugin.json の hooks フィールド削除でマニフェスト検証エラーを解消（3.0.1）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "apd",
       "source": "./",
       "description": "APD (Autopilot Development) Framework - 人間は意思決定だけ、AIが自律で完走する",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "author": {
         "name": "koyakimu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apd",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "APD (Autopilot Development) Framework - AI自律開発フレームワーク。人間は意思決定だけ、AIが自律で完走する。",
   "author": {
     "name": "koyakimu",
@@ -14,6 +14,5 @@
     "development",
     "framework",
     "ai-driven"
-  ],
-  "hooks": "hooks/hooks.json"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.1] - 2026-06-28
+
+### Fixed
+
+- **プラグインマニフェストの検証エラーを修正**: `plugin.json` の `"hooks": "hooks/hooks.json"` フィールドがスキーマに弾かれ（`hooks: Invalid input`）プラグイン全体がロード失敗していた。フィールドを削除し、`hooks/hooks.json` の自動検出に任せる方式（公式プラグインと同じ）に変更
+
 ## [3.0.0] - 2026-06-28
 
 ### Changed (Breaking) — APD v3: 実装中ゼロ介入の自動完走モデル


### PR DESCRIPTION
## 概要

v3.0.0（#29）で `plugin.json` に追加した `"hooks": "hooks/hooks.json"` がプラグインマニフェストのスキーマに存在しないフィールドで、`/reload-plugins` 時に **`hooks: Invalid input` で apd プラグイン全体がロード失敗**していた。

## 原因

公式プラグイン（superpowers）は `plugin.json` に `hooks` フィールドを書かず、`hooks/hooks.json` を**規約で自動検出**させている。`hooks` を manifest に明示するのは不正だった（`hooks/hooks.json` の中身自体は正しい形式）。

## 修正

- `plugin.json` から `hooks` フィールドを削除し、`hooks/hooks.json` の自動検出に委ねる
- 3.0.1 に bump（`plugin.json` / `marketplace.json`）+ CHANGELOG 追記

## 検証

- JSON 妥当性: `plugin.json` / `marketplace.json` / `hooks.json` すべて OK
- `hooks/hooks.json` 自動検出の実証: superpowers の SessionStart フックが同方式（manifest に `hooks` フィールドなし）で動作している

🤖 Generated with [Claude Code](https://claude.com/claude-code)