### PR TITLE
fix: suggest-next.sh が実際の hook_event_name を返す（3.0.3）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "apd",
       "source": "./",
       "description": "APD (Autopilot Development) Framework - 人間は意思決定だけ、AIが自律で完走する",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "author": {
         "name": "koyakimu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apd",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "APD (Autopilot Development) Framework - AI自律開発フレームワーク。人間は意思決定だけ、AIが自律で完走する。",
   "author": {
     "name": "koyakimu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.3] - 2026-06-28
+
+### Fixed
+
+- **SessionStart フックの実行エラーを修正**: `suggest-next.sh` が `hookEventName` を `"Stop"` 固定で出力していたため、SessionStart として実行されると `Hook returned incorrect event name: expected 'SessionStart' but got 'Stop'` で失敗していた。stdin の `hook_event_name` を読み取り、実際のイベント名を返すように変更
+
 ## [3.0.2] - 2026-06-28
 
 ### Fixed

--- a/hooks/suggest-next.sh
+++ b/hooks/suggest-next.sh
@@ -8,11 +8,14 @@ if [ "$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false')" = "true" ]; 
   exit 0
 fi
 
+# 実際のイベント名（Stop / SessionStart など）を stdin から取得して返す
+EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "Stop"')
+
 PROJ="${CLAUDE_PROJECT_DIR:-.}"
 APD_DIR="$PROJ/docs/apd"
 
 suggest() {
-  jq -n --arg msg "$1" '{ "hookSpecificOutput": { "hookEventName": "Stop", "additionalContext": $msg } }'
+  jq -n --arg msg "$1" --arg ev "$EVENT" '{ "hookSpecificOutput": { "hookEventName": $ev, "additionalContext": $msg } }'
 }
 
 if [ ! -f "$APD_DIR/design.md" ]; then


### PR DESCRIPTION
## 概要

状態サジェストフック `suggest-next.sh` が出力 JSON の `hookEventName` を `"Stop"` 固定にしていたため、**SessionStart フックとして実行されると失敗**していた:

```
SessionStart:startup hook error
Failed to run: Hook returned incorrect event name: expected 'SessionStart' but got 'Stop'.
```

同じスクリプトを Stop と SessionStart の両方に登録しているのが背景。

## 修正

stdin のフック入力 JSON から `hook_event_name` を読み取り、出力の `hookEventName` に反映する（欠落時は `"Stop"` フォールバック）。

## 検証

- `bash -n` 構文 OK
- Stop 入力 → `hookEventName: "Stop"`
- SessionStart 入力 → `hookEventName: "SessionStart"`
- `hook_event_name` 欠落 → `"Stop"` フォールバック
- `stop_hook_active=true` → 無出力（ループガード維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)