### PR TITLE
feat: マイグレーションを完全化（CLAUDE.md 掃除・rules 最新化・3.x 刷新, 3.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "apd",
       "source": "./",
       "description": "APD (Autopilot Development) Framework - 人間は意思決定だけ、AIが自律で完走する",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "author": {
         "name": "koyakimu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apd",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "APD (Autopilot Development) Framework - AI自律開発フレームワーク。人間は意思決定だけ、AIが自律で完走する。",
   "author": {
     "name": "koyakimu",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.3.0] - 2026-06-29
+
+### Changed — マイグレーションを完全化（CLAUDE.md 掃除・rules 最新化・3.x 刷新）
+
+- **`/apd:migrate` が CLAUDE.md を掃除するようになった**: APD 由来の注入を first-class で除去。宣伝行（`APD … フレームワーク x.y.z … で開発`）、`.claude/rules/apd/` の丸写し節、陳腐化記述（廃止済みの Spec チェック Stop フック参照・旧エスカレーション二分リスト）、旧コマンド/エージェント名（`/apd:build|start|cycle|progress`、`apd:peer-review|checkpoint`）、旧用語（Acceptance/Human Checkpoint）を対象に、**プロジェクト固有は残して**整理する
+- **`/apd:migrate` が `.claude/rules/apd/` を最新版に更新するようになった**: 差分確認の上でプラグイン同梱版へ更新（独自カスタムは手動レビューへ）。従来「`/apd:init` の責務」として委譲していたのを migrate に統合
+- **2.x → 3.x 移行パターンを追加**: 用語・コマンド・フックの刷新（Stop フック/サジェストフック廃止、`/apd:go`、完成後の実機確認）を移行対象に明記。移行は冪等
+- **`scripts/verify-migration.sh` を拡張**: CLAUDE.md の APD 汚れ（宣伝行・Stop フック参照・旧エスカレーション・旧コマンド）と `.claude/rules/apd/` の鮮度（陳腐化記述・プラグインとの差分）を検査
+- **再注入の防止**: `/apd:init` と `rules/apd/00-principles.md` に「APD はユーザーの CLAUDE.md を書き換えない」ガードを追加
+- `MIGRATION.md` を 3.x（CLAUDE.md 掃除・rules 最新化・新コマンド/用語）に更新
+
 ## [3.2.0] - 2026-06-28
 
 ### Changed — Spec チェックを Stop フックから Build のステップへ移管

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,14 @@
 # APD Migration Guide
 
-既存 APD プロジェクトを現行の「生きたドキュメント」モデルへ移行する手順。0.x（サブディレクトリ構造）からでも、1.0.x（フラット + Patch ファイル）からでも、同じ `/apd:migrate` で現行モデルに揃う。
+既存 APD プロジェクトを現行モデルへ移行する手順。0.x（サブディレクトリ構造）・1.0.x（フラット + Patch ファイル）・2.x（用語/コマンド/フックが旧式）のいずれからでも、同じ `/apd:migrate` で現行モデルに揃う。移行対象は `docs/apd/` の構造だけでなく **CLAUDE.md と `.claude/rules/apd/`** も含む。
 
 現行モデルの要点:
 - ドキュメントは生きた 1 枚（差分を別ファイルで積まない、git が正史）
 - 3 ファイル種別: `design.md` / `decisions.md` / `spec-{feature}.md`
 - Patch ファイル廃止 → 親 Spec に畳む。Decision は単一 `decisions.md` に集約。Preview は任意
 - 人間の確認面は GitHub（PR + issue）
+- 用語・コマンド・フックは 3.x: **完成後の実機確認** / `/apd:go` / プラグインは Stop・SessionStart フックを持たない
+- **CLAUDE.md はプロジェクト固有のことだけ**。APD 汎用ルールの正本は `.claude/rules/apd/`（自動ロード）に一本化
 
 ## アプローチ
 
@@ -30,14 +32,17 @@
 | Decision | `decisions/D-{NNN}.md` (0.x) / `decision-{NNN}.md` (1.0.x) | `docs/apd/decisions.md` (単一の追記ログ) |
 | Preview | 原則必須 | **任意**。作る場合のみ `docs/apd/preview-{feature}/` |
 | Cycle | `docs/apd/cycles/C-{NNN}.md` | **廃止** (GitHub issue で代替) |
-| Build スキル | `/apd:build` | `/apd:start <spec>` + `/goal` |
+| Build スキル | `/apd:build` / `/apd:start` | `/apd:go <spec>` + `/goal` |
 | サイクル開始 | `/apd:cycle` | 会話 + `gh issue create` |
-| 進行確認 | `/apd:progress` | `gh issue list` + `ls docs/apd/` + `/memory` |
-| 機械検証 agent | `apd:checkpoint` | **廃止** (`/goal` 評価器が代替) |
+| 進行確認 | `/apd:progress` | `/apd:status` + `gh issue list` + `ls docs/apd/` |
+| 機械検証 agent | `apd:checkpoint` / `apd:peer-review` | **廃止** (`/goal` 評価器 + Build の Spec チェックステップ) |
+| Spec チェック | Stop フック (3.0〜3.1) | **Build の達成条件**（ビルド AI が AC を照合） |
+| 次コマンド案内 | 状態サジェストフック (3.1) | 常駐ルール `07-next-step.md` + `/apd:status` |
 | Handoff | サイクル定義ファイル | PR 本文の「## 試し方」セクション |
 | Backlog | `docs/apd/todo.md` | GitHub issue (gh 環境) / `todo.md` (フォールバック) |
 | 人間の確認面 | docs/apd/ をスキャン | **GitHub (PR + issue)**。docs/apd/ は AI の作業場 |
-| 用語 | "Amendment" / "Human Checkpoint 2" | (廃止) / "Acceptance" |
+| 用語 | "Amendment" / "Acceptance" / "Human Checkpoint" | (廃止) / **完成後の実機確認** |
+| CLAUDE.md | APD 汎用ルールを丸写し・宣伝行 | **プロジェクト固有のみ**。汎用ルールは `.claude/rules/apd/` |
 
 ## 移行手順
 
@@ -66,10 +71,10 @@ Claude Code 内で:
 
 AI が以下を実行する:
 
-1. `docs/apd/` を読んで現状を把握
-2. **移行プランを提示** (どのファイルがどう動くか、frontmatter / 本文がどう書き換わるか、手動レビューが必要な箇所はどれか)
+1. `docs/apd/`・`CLAUDE.md`・`.claude/rules/apd/` を読んで現状を把握
+2. **移行プランを提示** (ファイル移動・frontmatter / 本文の書き換え・CLAUDE.md から除く APD 由来の記述・rules の更新・手動レビューが必要な箇所)
 3. ユーザーが yes と返したら実行
-4. バックアップ → ファイル移動 → frontmatter 更新 → 本文参照更新
+4. バックアップ（docs/apd/ と CLAUDE.md）→ ファイル移動 → frontmatter 更新 → 本文参照更新 → **CLAUDE.md の掃除**（宣伝行・汎用ルールの丸写し・陳腐化記述・旧コマンド名を除去、固有は残す）→ **`.claude/rules/apd/` を最新版に更新**
 5. `scripts/verify-migration.sh` を呼んで結果を検証
 6. レポート出力 (何をしたか・手動レビュー残項目)
 
@@ -89,18 +94,15 @@ bash <path-to-apd-plugin>/scripts/verify-migration.sh
 - **Patch ファイル (`spec-*-patch-*.md`) が残っていないか**（親 Spec に畳み込み済みか）
 - **per-file Decision (`D-*.md` / `decision-*.md`) が残っていないか**（`decisions.md` に集約済みか）
 - 旧 frontmatter フィールド (`amendment_id:`, `patch_id:`, `cycle_ref:`) が残っていないか
-- `docs/apd/` 配下に旧パス参照がないか
-- CLAUDE.md の旧スキル言及 (`/apd:build` 等) — warning のみ
+- `docs/apd/`・CLAUDE.md に旧サブディレクトリパス参照がないか
+- **CLAUDE.md の APD 汚れ**: 宣伝行（`APD … フレームワーク x.y.z … で開発`）、廃止済み「Spec チェック Stop フック」参照、旧「エスカレーションポリシー」二分リスト、旧コマンド/エージェント（`/apd:build|start|cycle|progress`、`apd:peer-review|checkpoint`）が残っていないか
+- **`.claude/rules/apd/` の鮮度**: 存在するか、`Stop フック` 等の陳腐化記述が無いか、（`CLAUDE_PLUGIN_ROOT` 設定時）インストール済みプラグインの rules と一致するか
 
 PASS / FAIL を表示し、FAIL があれば exit 1。
 
-### 5. ルールファイルを最新版に更新
+### 5. ルールファイル（`.claude/rules/apd/`）の更新
 
-```
-/apd:init
-```
-
-`.claude/rules/apd/*.md` が新方針版で上書きされる。`docs/apd/` は既に flat なので追加は発生しない。
+`/apd:migrate` が最新版へ更新する（上書き前に差分を確認し、独自カスタムがあれば手動レビューに倒す）。migrate を使わず手動で揃える場合は `/apd:init` でも `.claude/rules/apd/*.md` が最新版で上書きされる。
 
 ### 6. 残った手動レビュー項目を対応
 
@@ -108,7 +110,8 @@ PASS / FAIL を表示し、FAIL があれば exit 1。
 
 - 命名規約に合わなかったファイル (`random.md` 等): 用途を判断して新名で配置 or 削除
 - 古い version の Spec: backup から拾うか、backup のみで済ますか
-- CLAUDE.md の `/apd:build` 等の言及: 新スキル名に書き換え or 削除
+- CLAUDE.md で「汎用 APD ルールか / プロジェクト固有か」の判断が分かれた節（migrate が削除を保留したもの）
+- `.claude/rules/apd/` に独自カスタムがあったファイル（最新版で上書きするか、カスタムを残すか）
 
 ### 7. 動作確認
 
@@ -121,15 +124,16 @@ ls docs/apd/
 
 ```
 # Claude Code 内で (動作確認用、本物のサイクルでなくても)
+/apd:status   # 現在地と次の一手が出るか
 /apd:spec     # 既存 Spec が新形式で読み込めるか
-/apd:start spec-{slug}.md  # /goal condition が組み立てられるか
+/apd:go spec-{slug}.md  # /goal condition が組み立てられるか
 ```
 
 ### 8. コミット
 
 ```bash
 git add -A
-git commit -m "chore: migrate to APD 1.x"
+git commit -m "chore: migrate to current APD model"
 ```
 
 backup ディレクトリ (`docs/apd.backup-{timestamp}/`) は安全のためコミットに含めて残し、数サイクル運用して問題なければ別 PR で削除するのが安全。
@@ -141,7 +145,8 @@ backup ディレクトリ (`docs/apd.backup-{timestamp}/`) は安全のためコ
 ```bash
 rm -rf docs/apd
 mv docs/apd.backup-{timestamp} docs/apd
-git checkout -- .  # frontmatter 等の Edit が staged されている場合
+mv CLAUDE.md.apd-backup-{timestamp} CLAUDE.md   # CLAUDE.md を掃除した場合
+git checkout -- .claude/rules/apd/ .  # rules 更新や Edit が staged されている場合
 ```
 
 または `/plugin install apd@apd-marketplace --version 0.5.1` で旧プラグインに戻す。

--- a/rules/apd/00-principles.md
+++ b/rules/apd/00-principles.md
@@ -8,6 +8,7 @@
 - **人間の確認面は GitHub（PR + issue）。** `docs/apd/` は AI の作業材料であって、人間が日常的にスキャンする場所ではない
 - **判断に迷ったら自己判断せずリーダーエージェント（AI）に聞く。** 人間への問い合わせではない（Build 中は人間に問い合わせない）。聞きすぎるほうが暴走するより安全
 - **薄い規約レイヤに留める。** APD は Design / Spec / Decision の規約と最小限のスキルだけを提供する。ループ・並列化・タスク管理・GitHub 連携は Claude Code 本体の機能（`/goal`, agent teams, subagents, hooks, TaskCreate）に委譲する
+- **APD はユーザーの CLAUDE.md を書き換えない。** APD の規約は `.claude/rules/apd/`（自動ロード）に置く。CLAUDE.md に「APD で開発」等の使用宣言・バージョンを書き込まない（腐る・二重管理になる）。CLAUDE.md はプロジェクト固有のことだけ
 
 ## 判断の優先順位（Build 中）
 

--- a/scripts/verify-migration.sh
+++ b/scripts/verify-migration.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# Verify that an APD project has been migrated from 0.x to 1.x layout.
+# Verify that an APD project matches the current model: flat docs/apd/
+# layout, a CLAUDE.md free of APD injection/duplication/stale text, and
+# up-to-date .claude/rules/apd/.
 #
 # Usage:
 #   cd /path/to/your/project
 #   bash <path-to-apd-plugin>/scripts/verify-migration.sh
+#   # (set CLAUDE_PLUGIN_ROOT to also diff rules against the installed plugin)
 #
-# Returns exit 0 if the project's docs/apd/ structure is in the expected
-# 1.x flat layout. Returns exit 1 if any issues are detected, listing them.
+# Returns exit 0 if everything is in the expected current layout.
+# Returns exit 1 if any issues are detected, listing them.
 #
 # This is a CHECK ONLY script. It does not move or rewrite anything.
 # The actual migration is done by the /apd:migrate skill (AI-driven).
@@ -36,7 +39,7 @@ warn() {
   WARNINGS+=("$1")
 }
 
-echo "=== APD 1.x Migration Verification ==="
+echo "=== APD Migration Verification ==="
 echo ""
 
 # ----------------------------------------------------------------------
@@ -162,20 +165,100 @@ fi
 
 if [[ -f "CLAUDE.md" ]]; then
   if grep -qE 'docs/apd/(design|specs|decisions|cycles|previews)/' CLAUDE.md 2>/dev/null; then
-    warn "CLAUDE.md references old subdirectory paths"
-  fi
-  if grep -qE '/apd:(build|cycle|progress)' CLAUDE.md 2>/dev/null; then
-    warn "CLAUDE.md references deprecated skills (/apd:build, /apd:cycle, /apd:progress)"
+    fail "CLAUDE.md references old subdirectory paths"
+  else
+    pass "CLAUDE.md has no old subdirectory path references"
   fi
 fi
 
 echo ""
 
 # ----------------------------------------------------------------------
-# Check 5: Backup directory exists (recommended)
+# Check 5: CLAUDE.md is free of APD injection / duplication / stale text
 # ----------------------------------------------------------------------
 
-echo "Check 5: Backup retention"
+echo "Check 5: CLAUDE.md cleanliness (APD cruft removed)"
+
+if [[ -f "CLAUDE.md" ]]; then
+  # Injected banner line: "APD ... フレームワーク x.y.z ... で開発"
+  if grep -qE 'APD.*(フレームワーク|Framework).*[0-9]+\.[0-9]+\.[0-9]+.*(で開発|powered by|built with)' CLAUDE.md 2>/dev/null \
+     || grep -qE 'フレームワーク[^\n]*[0-9]+\.[0-9]+\.[0-9]+[^\n]*で開発' CLAUDE.md 2>/dev/null; then
+    fail "CLAUDE.md still has an injected APD version banner (remove it)"
+  else
+    pass "CLAUDE.md has no injected APD version banner"
+  fi
+
+  # Stale: removed Spec-check Stop hook
+  if grep -qE 'Spec ?チェック.*Stop ?フック|Stop ?フック.*Spec ?チェック' CLAUDE.md 2>/dev/null; then
+    fail "CLAUDE.md references the removed Spec-check Stop hook (now a Build step)"
+  else
+    pass "CLAUDE.md has no Spec-check Stop hook reference"
+  fi
+
+  # Stale: removed v2 escalation two-list
+  if grep -qE 'エスカレーションポリシー|Build 内で完結' CLAUDE.md 2>/dev/null; then
+    fail "CLAUDE.md has the old escalation policy two-list (removed model)"
+  else
+    pass "CLAUDE.md has no old escalation policy block"
+  fi
+
+  # Deprecated commands / agents
+  if grep -qE '/apd:(build|start|cycle|progress)|apd:(peer-review|checkpoint)' CLAUDE.md 2>/dev/null; then
+    fail "CLAUDE.md references deprecated commands/agents (/apd:build|start|cycle|progress, apd:peer-review|checkpoint)"
+  else
+    pass "CLAUDE.md has no deprecated command/agent references"
+  fi
+
+  # Duplicated generic rule section heading
+  if grep -qE '^##+ +APD 準拠ルール' CLAUDE.md 2>/dev/null; then
+    warn "CLAUDE.md has an 'APD 準拠ルール' section — likely duplicates .claude/rules/apd/ (move generic rules out)"
+  fi
+else
+  warn "CLAUDE.md not found (skipped CLAUDE.md cleanliness checks)"
+fi
+
+echo ""
+
+# ----------------------------------------------------------------------
+# Check 6: .claude/rules/apd/ is present and not stale
+# ----------------------------------------------------------------------
+
+echo "Check 6: .claude/rules/apd/ freshness"
+
+if [[ -d ".claude/rules/apd" ]]; then
+  pass ".claude/rules/apd/ exists"
+  # Stale rule content: Stop-hook wording removed in 3.2.0
+  if grep -rqE 'Stop ?フック' .claude/rules/apd/ 2>/dev/null; then
+    fail ".claude/rules/apd/ still mentions 'Stop フック' (stale — re-copy from the plugin / run /apd:migrate)"
+  else
+    pass ".claude/rules/apd/ has no stale Stop-hook wording"
+  fi
+  # Compare against the installed plugin rules when available
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -d "${CLAUDE_PLUGIN_ROOT}/rules/apd" ]]; then
+    drift=0
+    for f in "${CLAUDE_PLUGIN_ROOT}/rules/apd/"*.md; do
+      base=$(basename "$f")
+      if [[ ! -f ".claude/rules/apd/${base}" ]] || ! diff -q ".claude/rules/apd/${base}" "$f" >/dev/null 2>&1; then
+        drift=$((drift + 1))
+      fi
+    done
+    if [[ "$drift" -gt 0 ]]; then
+      warn ".claude/rules/apd/ differs from the installed plugin in ${drift} file(s) (version drift or local customization)"
+    else
+      pass ".claude/rules/apd/ matches the installed plugin rules"
+    fi
+  fi
+else
+  warn ".claude/rules/apd/ not found (run /apd:init or /apd:migrate to install rules)"
+fi
+
+echo ""
+
+# ----------------------------------------------------------------------
+# Check 7: Backup directory exists (recommended)
+# ----------------------------------------------------------------------
+
+echo "Check 7: Backup retention"
 backup_count=$(find . -maxdepth 2 -type d -name "apd.backup-*" 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$backup_count" -gt 0 ]]; then
   pass "Backup directory present (recommended to keep for several cycles)"

--- a/scripts/verify-migration.sh
+++ b/scripts/verify-migration.sh
@@ -195,11 +195,12 @@ if [[ -f "CLAUDE.md" ]]; then
     pass "CLAUDE.md has no Spec-check Stop hook reference"
   fi
 
-  # Stale: removed v2 escalation two-list
-  if grep -qE 'エスカレーションポリシー|Build 内で完結' CLAUDE.md 2>/dev/null; then
-    fail "CLAUDE.md has the old escalation policy two-list (removed model)"
+  # Stale: removed v2 escalation two-list (APD-specific phrasing only, to avoid
+  # flagging a project's own unrelated escalation policy)
+  if grep -qE 'Build 中のエスカレーションポリシー|Build 内で完結してよい' CLAUDE.md 2>/dev/null; then
+    fail "CLAUDE.md has the old APD escalation policy two-list (removed model)"
   else
-    pass "CLAUDE.md has no old escalation policy block"
+    pass "CLAUDE.md has no old APD escalation policy block"
   fi
 
   # Deprecated commands / agents

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -84,3 +84,4 @@ backlog の運用:
 - ルールファイルは `.claude/rules/apd/` にコピーされ、Claude Code が自動でコンテキストにロードする
 - `docs/apd/` はフラット構造。サブディレクトリは「必要になったら作る」原則
 - 次回のセッションから APD フレームワークのルールが自動適用される
+- **CLAUDE.md は変更しない。** APD の使用宣言やバージョンを CLAUDE.md に書き込まない（APD の存在は `.claude/rules/apd/` と `docs/apd/` で判る。バージョン入りの行は腐る）。CLAUDE.md はユーザーのもの

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: migrate
 description: >
-  Migrates an existing APD project to the current living-document
-  layout. Folds Patch files into their Spec, consolidates per-file
-  Decision Records into a single decisions.md, flattens any old
-  subdirectories, and updates frontmatter. Use when the user asks
-  to migrate APD, upgrade APD, run /apd:migrate, or has just updated
-  the APD plugin and needs to convert their `docs/apd/`.
+  Migrates an existing APD project to the current model: folds Patch
+  files into their Spec, consolidates per-file Decision Records into a
+  single decisions.md, flattens old subdirectories, updates frontmatter,
+  cleans APD cruft out of CLAUDE.md (injected banners, duplicated/stale
+  rules, deprecated commands), and refreshes .claude/rules/apd/ to the
+  installed version. Use when the user asks to migrate APD, upgrade APD,
+  run /apd:migrate, or has just updated the APD plugin.
 disable-model-invocation: true
 argument-hint: "[--dry-run]"
 ---
 
-# APD Migrate — 既存プロジェクトを「生きたドキュメント」構造へ移行
+# APD Migrate — 既存プロジェクトを現行モデルへ移行
 
-このスキルは **AI 判断ベースで** 既存 APD プロジェクトを現行モデルに移行する。現行モデルの要点:
+このスキルは **AI 判断ベースで** 既存 APD プロジェクトを現行モデルに揃える。対象は `docs/apd/` の構造だけでなく、**CLAUDE.md と `.claude/rules/apd/`** も含む。現行モデルの要点:
 
 - ドキュメントは生きた 1 枚（差分を別ファイルで積まない、git が正史）
 - 3 ファイル種別: `design.md` / `decisions.md` / `spec-{feature}.md`
@@ -21,22 +22,31 @@ argument-hint: "[--dry-run]"
 - Decision は per-file をやめて単一 `decisions.md` に集約
 - Preview は任意
 - 人間の確認面は GitHub（PR + issue）
+- 用語・コマンド・フックは現行（3.x）に統一: **完成後の実機確認** / `/apd:go` / プラグインは Stop・SessionStart フックを持たない
+- **CLAUDE.md は「プロジェクト固有のことだけ」**。APD 汎用ルールの正本は `.claude/rules/apd/`（自動ロード）に一本化する
 
 検証は `scripts/verify-migration.sh` で行う（プラグイン同梱）。
 
-## 移行元の 2 パターン
+## 移行元のパターン
 
-プロジェクトの現状を見て、どちらか（or 両方）を適用する:
+プロジェクトの現状を見て、該当するもの（複数可）を適用する:
 
 - **0.x（サブディレクトリ構造）**: `docs/apd/{design,specs,decisions,cycles,previews}/` がある
 - **1.0.x（フラット + Patch ファイル）**: `docs/apd/spec-*-patch-*.md` や `decision-*.md` が並んでいる
+- **2.x → 3.x（用語・コマンド・フックの刷新）**: ドキュメント構造は現行でも、CLAUDE.md・本文・rules に旧 3.x 以前の記述が残っている。具体的には:
+  - 「Acceptance」「Human Checkpoint」→ **完成後の実機確認**
+  - `/apd:build` / `/apd:start` → `/apd:go`、`/apd:cycle` / `/apd:progress` は廃止（会話 + `gh`）
+  - `apd:peer-review` / `apd:checkpoint` エージェント → 廃止
+  - **Spec チェック Stop フック**（3.0〜3.1）→ 廃止。Build の達成条件でビルド AI 自身が AC を照合する
+  - **状態サジェストフック**（3.1）→ 廃止。案内はメイン AI の常駐ルール（`07-next-step.md`）+ `/apd:status`
 
 ## 責務
 
-- 既存 `docs/apd/` を読んで現状を把握する
-- 現行モデルへの移行プランを立てる
-- ユーザーに確認を取る
+- 既存 `docs/apd/`・`CLAUDE.md`・`.claude/rules/apd/` を読んで現状を把握する
+- 現行モデルへの移行プランを立て、ユーザーに確認を取る
 - バックアップを取った上で移行を実行する
+- **CLAUDE.md から APD 由来の注入・重複・陳腐化を除去**する（プロジェクト固有は残す）
+- **`.claude/rules/apd/` を最新版に更新**する
 - 機械的に変換できない箇所は **手動レビュー項目として明示** する
 - 完了後に `scripts/verify-migration.sh` を実行して検証する
 
@@ -45,70 +55,63 @@ argument-hint: "[--dry-run]"
 ### 1. 前提確認
 
 - git working tree が clean（or 専用ブランチ）であること。clean でなければ実行せず、commit/stash/別ブランチを促す
-- `docs/apd/` が存在すること
-- 既に現行モデル（`design.md` あり、`spec-*-patch-*.md` と `decision-*.md` と旧サブディレクトリがいずれも無い）なら "already migrated" と返して終了
+- `docs/apd/` または `.claude/rules/apd/` が存在すること（APD プロジェクトであること）
+- **完全に現行モデル**（`docs/apd/` がフラット 3 種別・Patch/per-file Decision・旧サブディレクトリなし、CLAUDE.md に APD 由来の注入/陳腐化なし、rules が最新版と一致）なら "already migrated" と返して終了。**冪等**: 既に揃っている項目はスキップする
 
 ### 2. 現状把握
 
-`docs/apd/` 配下を Glob + Read で全把握する:
+Glob + Read + Bash で以下を把握する:
 
-- 旧サブディレクトリ（`design/`, `specs/`, `decisions/`, `cycles/`, `previews/`）の有無
-- `spec-{x}-patch-{NNN}.md`（フラット Patch ファイル）一覧と、対応する親 `spec-{x}.md`
-- `decision-{NNN}.md`（per-file Decision）一覧
-- `preview-*/` 一覧
-- 命名規約に合わないファイル
+- **docs/apd/**: 旧サブディレクトリ、`spec-*-patch-*.md`、`decision-*.md` / `D-*.md`、`preview-*/`、命名規約外ファイル
+- **CLAUDE.md**: APD 由来の記述を洗い出す（次の「CLAUDE.md の掃除」の対象一覧で grep する）
+- **.claude/rules/apd/**: プラグイン同梱（`${CLAUDE_PLUGIN_ROOT}/rules/apd/`）との差分を `diff` で確認。差分が「版の違い」か「プロジェクト独自カスタム」かを見分ける
 
 ### 3. 移行プランの提示と確認
 
-以下のような形式でプランを提示し、合意を得る:
-
-````markdown
-## 移行プラン
-
-### バックアップ
-- `docs/apd/` を `docs/apd.backup-{timestamp}/` に複製
-
-### サブディレクトリの flat 化（0.x からの場合）
-- `design/product-design.md` → `design.md`
-- `specs/{name}.v{N}.md` → `spec-{name}.md`（最新 version）
-- `decisions/D-{NNN}.md` → `decisions.md` に集約
-- `previews/C-{NNN}/` → `preview-C-{NNN}/`
-- `cycles/` → backup のみ
-
-### Patch ファイルの畳み込み
-- `spec-auth-patch-001.md` の内容を `spec-auth.md` に反映し version を上げる
-- 反映後 patch ファイルを削除
-- 反映内容の要約をコミットメッセージに残す
-
-### Decision の集約
-- `decision-001.md` … `decision-NNN.md` を `decisions.md` に 1 ファイルへ統合
-- 各ファイルを decisions.md のセクションに変換（新しい番号を上に）
-- 元の per-file は削除
-
-### frontmatter 更新
-- 全 Spec: `cycle_ref` → `issue_ref`（実 issue があれば番号、なければ null）
-- Patch 由来: `amendment_id` / `patch_id` フィールドは畳み込みで消える
-
-### 手動レビューが必要なもの
-- {命名規約に合わないファイル}
-- CLAUDE.md の旧スキル言及（`/apd:build` 等）
-
-進めてよいですか? (yes / dry-run / abort)
-````
-
-`--dry-run` 引数があれば、プラン提示と「実行した場合に何が起こるか」だけ出力する（fs 操作なし）。
+何を・どう変えるか（docs / CLAUDE.md / rules）と、手動レビューに倒すものを列挙して合意を得る。`--dry-run` 引数があれば、プラン提示と「実行した場合に何が起こるか」だけ出力する（fs 操作なし）。
 
 ### 4. 実行
 
-ユーザー合意後、Bash + Edit で順番に実行する。各ステップ後に**何をしたか**を会話に surface する:
+ユーザー合意後、Bash + Edit で順番に実行する。各ステップ後に**何をしたか**を会話に surface する。
 
-1. **バックアップ**: `cp -R docs/apd docs/apd.backup-{timestamp}`（絶対消さない）
+1. **バックアップ**: `cp -R docs/apd docs/apd.backup-{timestamp}`、`cp CLAUDE.md CLAUDE.md.apd-backup-{timestamp}`（絶対消さない。専用ブランチがあればそれも保険）
 2. **サブディレクトリ flat 化**（0.x の場合）: `git mv` でファイル移動
-3. **Patch 畳み込み**: 各 patch ファイルを Read → 親 Spec を Edit して内容反映 + `version` 加算 → patch ファイルを `git rm`
-4. **Decision 集約**: 各 `decision-*.md` を Read → `decisions.md` に追記（番号降順）→ 元ファイルを `git rm`
-5. **frontmatter 更新**: Edit で各 Spec の `cycle_ref` → `issue_ref` 等
+3. **Patch 畳み込み**: 各 patch を Read → 親 Spec の該当 AC を Edit で統合 + `version` 加算 → patch を `git rm`（機械的な末尾追記はしない。二重定義を避ける）
+4. **Decision 集約**: 各 `decision-*.md` を Read → `decisions.md` に番号降順で追記 → 元を `git rm`
+5. **frontmatter 更新**: `cycle_ref` → `issue_ref`、`amendment_id` / `patch_id` は畳み込みで除去
+6. **CLAUDE.md の掃除**（下記）
+7. **rules の最新化**（下記）
 
-**Patch 畳み込みの判断**: patch の内容が親 Spec のどの AC に対応するかを読み解いて、該当 AC を編集 or 新 AC として追加する。単純な追記では二重定義になるので、文脈を見て統合する。
+#### CLAUDE.md の掃除（APD 由来の注入・重複・陳腐化の除去）
+
+CLAUDE.md には APD 由来の記述が紛れ込みやすい。汎用の APD ルールは `.claude/rules/apd/`（自動ロード）が正本なので、CLAUDE.md からは除く。**プロジェクト固有の内容は必ず残す**（技術スタック・命名規約・テストランナー・CI・配信・セキュリティ・プロジェクト状態など）。AI が節・行ごとに「汎用 APD ルールか / プロジェクト固有か」を判断する。
+
+除去・修正の対象:
+
+- **宣伝行**: 「**APD（Autopilot Development）フレームワーク x.y.z …で開発。詳細ルール: `.claude/rules/apd/`**」のような APD 使用宣言・バージョン入りの行 → **削除**（バージョンは腐る。APD の存在は `.claude/rules/apd/` と `docs/apd/` で判る）
+- **汎用ルールの丸写し**: `.claude/rules/apd/` の内容を CLAUDE.md に重複させた節 → **削除**。典型: 「APD 準拠ルール」「並列実行・Git 戦略（…準拠）」、テスト方針の汎用部分、「Build の収束判定」、Decision 参照の一般則、生きたドキュメントの一般則。固有部分（テストランナー・モック禁止領域・ブランチ運用の独自規則など）があればそこだけ残す
+- **陳腐化した記述**:
+  - 「**Spec チェック Stop フック**」への言及 → 廃止済み。「Build の達成条件でビルド AI が AC を照合」に書き換え or 削除
+  - 「**Build 中のエスカレーションポリシー**」の二分リスト（人間に渡す / Build 内で完結）→ 旧モデル。削除（現行は「実装中ゼロ介入・完成後の実機確認で次サイクル」）
+  - 状態サジェストフックへの言及 → 削除（常駐ルール + `/apd:status`）
+- **旧コマンド・旧エージェント名**: `/apd:build` `/apd:start` `/apd:cycle` `/apd:progress` `apd:checkpoint` `apd:peer-review` → 現行（`/apd:go` 等）に書き換え or 削除
+- **旧用語**: 「Acceptance」「Human Checkpoint」→「完成後の実機確認」
+
+判断に迷う節は削除せず**手動レビュー項目**に倒す。
+
+#### rules の最新化
+
+`.claude/rules/apd/*.md` をプラグイン同梱の最新版に更新する。上書き前に必ず差分を確認し、プロジェクト独自カスタムがあれば手動レビューに倒す:
+
+```bash
+# 差分確認（版の違いのみか、独自カスタムが入っているか）
+for f in "${CLAUDE_PLUGIN_ROOT}/rules/apd/"*.md; do
+  diff -q ".claude/rules/apd/$(basename "$f")" "$f" 2>/dev/null
+done
+# 独自カスタムが無ければ最新版で上書き
+mkdir -p .claude/rules/apd
+cp "${CLAUDE_PLUGIN_ROOT}/rules/apd/"*.md .claude/rules/apd/
+```
 
 ### 5. 検証
 
@@ -120,53 +123,50 @@ FAIL があれば修正する。
 
 ### 6. レポート
 
-完了したらレポートを出す:
-
 ````markdown
 ## 移行完了
 
-### Patch 畳み込み (N 件)
-- spec-auth-patch-001.md → spec-auth.md (version 1→2)
+### docs/apd/
+- Patch 畳み込み (N 件) / Decision 集約 (N 件) / flat 化 (N 件) / frontmatter 更新 (N 件)
 
-### Decision 集約 (N 件 → decisions.md)
-- decision-001..003.md → decisions.md
+### CLAUDE.md の掃除
+- 削除: 宣伝行 / 汎用ルール節（…）/ 陳腐化記述（Stop フック・エスカレーション二分リスト 等）
+- 書き換え: 旧コマンド名・旧用語
+- 残した: プロジェクト固有（技術スタック・テストランナー・配信・セキュリティ 等）
 
-### flat 化 (N 件) ※0.x からの場合
-- ...
-
-### frontmatter 更新 (N ファイル)
-- ...
+### .claude/rules/apd/
+- N ファイルを最新版に更新（独自カスタム: なし / 手動レビューへ）
 
 ### 手動レビュー必要 (N 件)
 - ...
 
 ### バックアップ
-- docs/apd.backup-{timestamp}/
+- docs/apd.backup-{timestamp}/ ・ CLAUDE.md.apd-backup-{timestamp}
 
 ### 次のステップ
-1. /apd:init で .claude/rules/apd/ を最新版に更新
-2. 手動レビュー項目を対応
-3. git add -A && git commit -m "chore: migrate to APD living-document model"
-4. 動作確認後、別 PR で backup ディレクトリを削除
+1. 手動レビュー項目を対応
+2. git add -A && git commit -m "chore: migrate to current APD model"
+3. 動作確認後、別 PR で backup を削除
 ````
 
 ## 安全原則
 
-- **バックアップを取らずに変更しない**
+- **バックアップを取らずに変更しない**（docs/apd/ も CLAUDE.md も）
 - **判断に迷ったら手動レビュー項目に倒す**
-- **Patch 畳み込みは内容を読んでから**: patch を機械的に末尾追記せず、対応 AC に統合する
-- **Decision 集約は順序を保つ**: 元の番号・日付を保持して decisions.md に積む
-- **cycles の取り扱い**: backup のみに残す前に、重要な意思決定が書かれていないか Read で確認。あれば decisions.md に救出する
+- **CLAUDE.md はプロジェクト固有を必ず残す**: 汎用 APD ルールだけを除き、固有の規約・設定・状態は消さない
+- **rules の上書きは差分確認後**: 独自カスタムを握り潰さない
+- **Patch 畳み込みは内容を読んでから**、**Decision 集約は順序を保つ**
+- **冪等**: 再実行しても安全。既に現行のものはスキップする
 
 ## このスキルが意図的にやらないこと
 
-- `.claude/rules/apd/` の更新 — `/apd:init` の責務
-- プロジェクト固有の src/tests/ の path 更新 — 手動レビュー項目に倒す
+- プロジェクト固有の `src/` `tests/` の path 更新 — 手動レビュー項目に倒す
+- CLAUDE.md のプロジェクト固有内容の改変 — APD 由来の汎用ルール/注入/陳腐化のみを対象にする
 
 ## ロールバック
 
 ```bash
-rm -rf docs/apd
-mv docs/apd.backup-{timestamp} docs/apd
-git checkout -- .
+rm -rf docs/apd && mv docs/apd.backup-{timestamp} docs/apd
+mv CLAUDE.md.apd-backup-{timestamp} CLAUDE.md
+git checkout -- .claude/rules/apd/
 ```


### PR DESCRIPTION
## 背景

実プロジェクト（playbox）の移行で、`/apd:migrate` が **CLAUDE.md に紛れ込んだ APD 由来の注入・重複・陳腐化**と **`.claude/rules/apd/` の版ずれ**を扱えず、手作業での掃除が必要だった。これらを first-class にして「完璧な移行」にする。

## 変更

### `/apd:migrate`（skill）
- **CLAUDE.md の掃除を追加**: AI が節・行ごとに「汎用 APD ルール / プロジェクト固有」を判断し、以下を除去（**固有は残す**）:
  - 宣伝行（`APD … フレームワーク x.y.z … で開発`）
  - `.claude/rules/apd/` の丸写し節（`APD 準拠ルール`、`並列実行・Git 戦略（…準拠）` 等）
  - 陳腐化記述（廃止済み「Spec チェック Stop フック」参照、旧「Build 中のエスカレーションポリシー」二分リスト、状態サジェストフック）
  - 旧コマンド/エージェント（`/apd:build|start|cycle|progress`、`apd:peer-review|checkpoint`）、旧用語（Acceptance/Human Checkpoint）
- **`.claude/rules/apd/` の最新化を統合**: 差分確認の上で上書き（独自カスタムは手動レビューへ）
- **2.x→3.x 移行パターンを追加**・冪等化（再実行安全）

### `scripts/verify-migration.sh`
- CLAUDE.md の APD 汚れ（宣伝行・Stop フック参照・旧エスカレーション・旧コマンド）を検査
- `.claude/rules/apd/` の鮮度（陳腐化記述・`CLAUDE_PLUGIN_ROOT` 設定時はプラグインとの差分）を検査
- 誤検知防止: エスカレーション検査は APD 固有表現に限定

### 再注入の防止
- `/apd:init` と `rules/apd/00-principles.md` に「**APD はユーザーの CLAUDE.md を書き換えない**」ガードを追加

### docs
- `MIGRATION.md` を 3.x（CLAUDE.md 掃除・rules 最新化・新コマンド/用語）に更新
- 3.3.0 に bump

## 検証

- verify スクリプト: bash 構文 OK
- 移行済み playbox: 全 PASS（誤検知ゼロ）
- 汚れたサンプル（宣伝行・Stop フック・旧エスカレーション・旧コマンド・古い rules）: 該当 5 項目を正しく FAIL + 重複節を WARN
- 最新 `rules/apd/` に陳腐化記述が無いことを確認（最新プロジェクトでの誤 FAIL なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)